### PR TITLE
Behavior: finalize hands kept tabs to the blue OpenCode Deliverables group

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,4 +9,4 @@ The live registry distinguishes stable profile fingerprint, human label, transie
 - A disconnected selected profile returns `PROFILE_DISCONNECTED`; the session never falls back to another profile.
 - Reconnects invalidate stale tab handles and a session cannot claim another profile's tab.
 
-Use `browser_session` for `open`, `new-tab`, `claim-tab`, `release-tab`, and `name`. Call `browser_finalize` to release claimed tabs, close owned temporary tabs, and preserve only handoff or deliverable tabs.
+Use `browser_session` for `open`, `new-tab`, `claim-tab`, `release-tab`, and `name`. Call `browser_finalize` to release claimed tabs, close owned temporary tabs, and preserve kept tabs: `status: "deliverable"` (the default) moves a kept tab into the blue "OpenCode Deliverables" group, while `status: "handoff"` keeps it open and ungrouped.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,4 +9,4 @@ The live registry distinguishes stable profile fingerprint, human label, transie
 - A disconnected selected profile returns `PROFILE_DISCONNECTED`; the session never falls back to another profile.
 - Reconnects invalidate stale tab handles and a session cannot claim another profile's tab.
 
-Use `browser_session` for `open`, `new-tab`, `claim-tab`, `release-tab`, and `name`. Call `browser_finalize` to release claimed tabs, close owned temporary tabs, and preserve kept tabs: `status: "deliverable"` (the default) moves a kept tab into the blue "OpenCode Deliverables" group, while `status: "handoff"` keeps it open and ungrouped.
+Use `browser_session` for `open`, `new-tab`, `claim-tab`, `release-tab`, and `name`. Call `browser_finalize` to release claimed tabs, close owned temporary tabs, and preserve kept tabs: `status: "deliverable"` moves a kept tab into the blue "OpenCode Deliverables" group as a user-facing output, while `status: "handoff"` (the default) keeps it inside the session so work can continue in a later turn. Tabs marked `handoff` survive the current session and must be marked again at the end of a later turn if they must survive that turn too.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,13 +1,48 @@
-# Troubleshooting
+# Browser troubleshooting
 
-Run:
+Read the matching topic on demand before retrying a failed browser
+connection. Each topic describes the failure it covers and the recovery
+steps to try in order.
 
-```powershell
-opencode-chromium doctor --json
-bun run check:native-host -- --json
-bun run check:extension -- --browser chrome --extension-id <extension-id>
-```
+## discovery
 
-If no profile is connected, reload the unpacked extension and reinstall the native host with the current extension ID. If several profiles are connected, pass an exact profile ID or label. If tools are duplicated, disable either native OpenCode mode or MCP compatibility mode and run `doctor` again.
+Covers: browser setup succeeds (the native host is installed and the
+extension is present) but profile discovery or tab selection fails —
+for example the `browser_session` open step reports no usable profile,
+or a claimed tab turns out to be stale.
 
-For stale local builds, run `bun run build` and point clients to `dist/`. Release-fidelity testing should use the exact tarball produced by `bun run pack`.
+Recovery, in order:
+
+1. Call `browser_session` action `open` again without specifying a
+   profile label; the runtime resolves the default profile. If the
+   named profile was the issue, this isolates it.
+2. Check that the browser is running and unlocked (a locked profile
+   directory makes discovery report nothing). Unlock or relaunch the
+   browser, then retry.
+3. If a tab binding is reported missing, stale, or closed, discard
+   that binding and obtain or create a fresh tab from the session
+   — an empty tab list is normal after cleanup and does not invalidate
+   the session.
+4. Only an explicit browser-disconnected error invalidates the
+   session; do not treat per-tab staleness as a session failure.
+
+## installation
+
+Covers: the native host or the extension is missing, unregistered, or
+silently failing — for example `install-native-host` or `doctor`
+reports a disconnected host, messaging times out, or the browser never
+receives commands.
+
+Recovery, in order:
+
+1. Run `install-native-host` or the equivalent setup command from
+   `docs/profiles.md` for your client, then run the doctor command
+   (`doctor --budget N`) and read its report.
+2. Confirm the browser extension is enabled in the browser's extension
+   page (edge cases: brave and edge use their own extension stores;
+   the host manifest covers multiple extension ids).
+3. Refresh the extension page or restart the browser, then retry the
+   connection. The host re-registers itself on restart.
+4. If the host still reports `disconnected`, inspect the host log
+   path printed by `doctor` for a registration error and rerun the
+   installer, which repairs the native messaging registration.

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -366,7 +366,7 @@ function currentCursorStates(tabId) {
 
 function normalizeKeepItem(item) {
   const tabId = Number.isInteger(item) ? item : item?.tabId ?? item?.tab_id ?? item?.tab?.id;
-  const status = Number.isInteger(item) ? "deliverable" : item?.status ?? "deliverable";
+  const status = Number.isInteger(item) ? "handoff" : item?.status ?? "handoff";
   if (!Number.isInteger(tabId)) throw new Error("Expected keep item tabId");
   if (status !== "handoff" && status !== "deliverable") throw new Error(`Unsupported keep status: ${status}`);
   return { tabId, status };
@@ -1242,8 +1242,8 @@ rpc.register("finalizeTabs", async (params) => {
     if (status) {
       if (status === "deliverable") {
         await ensureDeliverableGroup(tabId).catch(() => {});
+        await untrackTab(id, tabId);
       }
-      await untrackTab(id, tabId);
       continue;
     }
 
@@ -1253,7 +1253,7 @@ rpc.register("finalizeTabs", async (params) => {
       continue;
     }
 
-    await chromeCall((done) => chrome.tabs.remove(tabId, done));
+    await chromeCall((done) => chrome.tabs.remove(tabId, done)).catch(() => {});
     await untrackTab(id, tabId);
   }
   await persistSessions().catch(() => {});

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -366,7 +366,7 @@ function currentCursorStates(tabId) {
 
 function normalizeKeepItem(item) {
   const tabId = Number.isInteger(item) ? item : item?.tabId ?? item?.tab_id ?? item?.tab?.id;
-  const status = Number.isInteger(item) ? "handoff" : item?.status ?? "handoff";
+  const status = Number.isInteger(item) ? "deliverable" : item?.status ?? "deliverable";
   if (!Number.isInteger(tabId)) throw new Error("Expected keep item tabId");
   if (status !== "handoff" && status !== "deliverable") throw new Error(`Unsupported keep status: ${status}`);
   return { tabId, status };

--- a/skills/opencode-browser-plugin/SKILL.md
+++ b/skills/opencode-browser-plugin/SKILL.md
@@ -29,7 +29,7 @@ For deeper network inspection of one controlled tab, request the lazy network pa
 
 The default network result is lifecycle-only. Headers are redacted, bodies are disabled by default, and `includeBody: "request" | "response" | "both"` is bounded, redacted, and approval-gated.
 
-When a result is `approval_required`, review the chain and call `browser_run` again with only `approvalToken`. Never recreate or modify the approved chain. Retrieve screenshots and oversized results from their artifact URI, and call `browser_finalize` when the work is complete while keeping only user-facing deliverables.
+When a result is `approval_required`, review the chain and call `browser_run` again with only `approvalToken`. Never recreate or modify the approved chain. Retrieve screenshots and oversized results from their artifact URI. When the work is complete, call `browser_finalize` and keep only user-facing deliverables with `keep: [{"tabId": <id>, "status": "deliverable"}]` — kept deliverables move into the blue "OpenCode Deliverables" group; use `"status": "handoff"` only to keep a tab open without that group. Agent-owned tabs that are not kept are closed; user-claimed tabs that are not kept are released without closing.
 
 Hover elements with a `hover` step to reveal menus and tooltips before clicking. Accept or dismiss JavaScript dialogs with `handleDialog` (`value: "accept" | "dismiss"`, optional `promptText`); accepting a dialog pauses the chain for approval. Capture screenshots as `png`, `jpeg`, or `webp` with an optional `quality` for the compressed formats. Pending dialogs appear in the `dialogs` bucket of `browser_observe` mode `events`.
 

--- a/skills/opencode-browser-plugin/SKILL.md
+++ b/skills/opencode-browser-plugin/SKILL.md
@@ -11,6 +11,10 @@ Use `browser_run`, `browser_observe`, `browser_session`, and `browser_finalize`.
 
 Reuse `sessionId`. Page search uses the Snowflake model by default. Pass `searchStrategy: "lexical"` for lowest latency, `"auto"` for lexical-first adaptive retrieval, or `"deep"` for multilingual, code-heavy, or genuinely semantic retrieval. Request advanced descriptions with `browser_observe` mode `capabilities`, then execute a capability through a `browser_run` step without adding top-level tools.
 
+Choose the browser surface deliberately. An explicit user request for a named profile or browser wins over URL-based selection; when no profile is named, let the target URL select the profile; with neither, use the default profile. Selection and discovery stay read-only — never inspect cookies, storage, profiles, passwords, or session stores. When authentication blocks a requested navigation, ask the user to sign in directly in their browser; do not substitute another profile or bypass the sign-in with a search engine, a mirror site, or any other source.
+
+When browser setup succeeds but discovery or selection fails, read `docs/troubleshooting.md` — topic `#discovery` — before retrying. When extension or native-host installation or communication fails, read `#installation` before taking another recovery action.
+
 For deeper network inspection of one controlled tab, request the lazy network pack and then run `network.inspect`:
 
 ```json
@@ -29,7 +33,12 @@ For deeper network inspection of one controlled tab, request the lazy network pa
 
 The default network result is lifecycle-only. Headers are redacted, bodies are disabled by default, and `includeBody: "request" | "response" | "both"` is bounded, redacted, and approval-gated.
 
-When a result is `approval_required`, review the chain and call `browser_run` again with only `approvalToken`. Never recreate or modify the approved chain. Retrieve screenshots and oversized results from their artifact URI. When the work is complete, call `browser_finalize` and keep only user-facing deliverables with `keep: [{"tabId": <id>, "status": "deliverable"}]` — kept deliverables move into the blue "OpenCode Deliverables" group; use `"status": "handoff"` only to keep a tab open without that group. Agent-owned tabs that are not kept are closed; user-claimed tabs that are not kept are released without closing.
+When a result is `approval_required`, review the chain and call `browser_run` again with only `approvalToken`. Never recreate or modify the approved chain. Retrieve screenshots and oversized results from their artifact URI. When the work is complete, call `browser_finalize` and pass `keep` only for tabs that must survive:
+
+- `{"tabId": <id>, "status": "deliverable"}` — the live tab itself is the user-facing output: a created or edited document, spreadsheet, dashboard, checkout, submitted form result, or a page the user explicitly asked to keep open. Deliverables move into the blue **OpenCode Deliverables** group.
+- `{"tabId": <id>, "status": "handoff"}` (the default when a status is omitted) — work must continue from the live page in a later turn: a page waiting for user input, login, approval, payment, CAPTCHA, or an unfinished workflow. Handoffs stay inside the session's green group and remain available in later turns; mark them again at the end of that later turn if they must survive it too, because the latest mark per tab wins.
+- Do not keep research, search, source, intermediate, duplicate, blank, or error pages. Extract what you need and let finalize close them.
+- Agent-created tabs that are not kept are closed; user-claimed tabs that are not kept are released without closing.
 
 Hover elements with a `hover` step to reveal menus and tooltips before clicking. Accept or dismiss JavaScript dialogs with `handleDialog` (`value: "accept" | "dismiss"`, optional `promptText`); accepting a dialog pauses the chain for approval. Capture screenshots as `png`, `jpeg`, or `webp` with an optional `quality` for the compressed formats. Pending dialogs appear in the `dialogs` bucket of `browser_observe` mode `events`.
 

--- a/src/adapters/mcp/server.js
+++ b/src/adapters/mcp/server.js
@@ -28,7 +28,7 @@ export const SERVER_INSTRUCTIONS = [
   "Pass a user-named profile on the first useful call, batch find/action/settle/verification in browser_run, and reuse sessionId.",
   "Page search uses Snowflake by default; request lexical or auto for lower-latency retrieval, and deep for genuinely semantic, multilingual, or code-heavy matching.",
   "For a specific tab's deeper network debugging, request browser_observe mode capabilities with pack network, then execute network.inspect inside browser_run; bodies are opt-in and approval-gated.",
-  "Approval-required results must be followed by browser_run with only the approvalToken. Call browser_finalize when finished: keep user-facing tabs as deliverables so they move into the blue OpenCode Deliverables group instead of being closed.",
+  "Approval-required results must be followed by browser_run with only the approvalToken. Call browser_finalize when finished: keep user-facing tabs as 'deliverable' so they move into the blue OpenCode Deliverables group; keep 'handoff' tabs only when work must continue in a later turn. Agent-owned tabs that are not kept are closed and user-claimed tabs that are not kept are released.",
 ].join(" ");
 
 function rootDir() {

--- a/src/adapters/mcp/server.js
+++ b/src/adapters/mcp/server.js
@@ -28,7 +28,7 @@ export const SERVER_INSTRUCTIONS = [
   "Pass a user-named profile on the first useful call, batch find/action/settle/verification in browser_run, and reuse sessionId.",
   "Page search uses Snowflake by default; request lexical or auto for lower-latency retrieval, and deep for genuinely semantic, multilingual, or code-heavy matching.",
   "For a specific tab's deeper network debugging, request browser_observe mode capabilities with pack network, then execute network.inspect inside browser_run; bodies are opt-in and approval-gated.",
-  "Approval-required results must be followed by browser_run with only the approvalToken. Call browser_finalize when finished.",
+  "Approval-required results must be followed by browser_run with only the approvalToken. Call browser_finalize when finished: keep user-facing tabs as deliverables so they move into the blue OpenCode Deliverables group instead of being closed.",
 ].join(" ");
 
 function rootDir() {

--- a/src/browser/operations/index.js
+++ b/src/browser/operations/index.js
@@ -3220,14 +3220,14 @@ browser_console_logs: tool({
       }),
 
 browser_finalize: tool({
-        description: "Keep user-facing tabs as blue OpenCode Deliverables; close agent-created tabs unless kept; release unkept user-claimed tabs without closing them.",
+        description: "End the session: keep tabs as \"deliverable\" (user-facing output, moved to the blue OpenCode Deliverables group) or \"handoff\" (work continues later, stays in the session's green group); default is handoff. Close agent-created tabs unless kept; release unkept user-claimed tabs without closing them.",
         args: {
           keep: tool.schema.array(
             tool.schema.union([
               tool.schema.number().int().positive(),
               tool.schema.object({
                 tabId: tool.schema.number().int().positive(),
-                status: tool.schema.enum(["handoff", "deliverable"]).default("deliverable"),
+                status: tool.schema.enum(["handoff", "deliverable"]).default("handoff"),
                 profileId: tool.schema.string().optional(),
               }),
             ]),
@@ -3235,7 +3235,7 @@ browser_finalize: tool({
         },
         async execute(args, context) {
           const profileIds = await targetProfileIdsForSession(context);
-          const keep = args.keep.map((item) => (typeof item === "number" ? { tabId: item, status: "deliverable" } : item));
+          const keep = args.keep.map((item) => (typeof item === "number" ? { tabId: item, status: "handoff" } : item));
           if (profileIds.length > 1 && keep.some((item) => !item.profileId)) {
             throw new Error("browser_finalize keep items must include profileId when multiple browser profiles were used");
           }

--- a/src/browser/operations/index.js
+++ b/src/browser/operations/index.js
@@ -3219,15 +3219,15 @@ browser_console_logs: tool({
         },
       }),
 
-      browser_finalize: tool({
-        description: "Close agent-created tabs unless kept; release unkept user-claimed tabs without closing them.",
+browser_finalize: tool({
+        description: "Keep user-facing tabs as blue OpenCode Deliverables; close agent-created tabs unless kept; release unkept user-claimed tabs without closing them.",
         args: {
           keep: tool.schema.array(
             tool.schema.union([
               tool.schema.number().int().positive(),
               tool.schema.object({
                 tabId: tool.schema.number().int().positive(),
-                status: tool.schema.enum(["handoff", "deliverable"]).default("handoff"),
+                status: tool.schema.enum(["handoff", "deliverable"]).default("deliverable"),
                 profileId: tool.schema.string().optional(),
               }),
             ]),
@@ -3235,7 +3235,7 @@ browser_console_logs: tool({
         },
         async execute(args, context) {
           const profileIds = await targetProfileIdsForSession(context);
-          const keep = args.keep.map((item) => (typeof item === "number" ? { tabId: item, status: "handoff" } : item));
+          const keep = args.keep.map((item) => (typeof item === "number" ? { tabId: item, status: "deliverable" } : item));
           if (profileIds.length > 1 && keep.some((item) => !item.profileId)) {
             throw new Error("browser_finalize keep items must include profileId when multiple browser profiles were used");
           }

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -188,12 +188,12 @@ export function createCoreRegistry(runtime) {
       execute: (args, context) => runtime.session(args, context),
     },
     browser_finalize: {
-      description: "Finalize a browser session.",
+      description: "Finalize a browser session. Kept tabs become blue OpenCode Deliverables by default; status 'handoff' keeps a tab open ungrouped. Agent-owned unkept tabs close and user-claimed unkept tabs are released.",
       inputSchema: z.object({
         ...sessionFields,
         keep: z.array(z.union([
           z.number().int().positive(),
-          z.object({ tabId: z.number().int().positive(), status: z.enum(["handoff", "deliverable"]).optional() }),
+          z.object({ tabId: z.number().int().positive(), status: z.enum(["handoff", "deliverable"]).optional().describe("'deliverable' moves the tab to the blue OpenCode Deliverables group; 'handoff' keeps it open ungrouped.") }),
         ])).max(50).optional(),
         keepEnvironment: z.boolean().optional().describe("Retain applied emulation overrides instead of clearing them."),
       }),

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -188,12 +188,12 @@ export function createCoreRegistry(runtime) {
       execute: (args, context) => runtime.session(args, context),
     },
     browser_finalize: {
-      description: "Finalize a browser session. Kept tabs become blue OpenCode Deliverables by default; status 'handoff' keeps a tab open ungrouped. Agent-owned unkept tabs close and user-claimed unkept tabs are released.",
+      description: "Finalize a browser session. 'deliverable' moves a kept tab into the blue OpenCode Deliverables group; 'handoff' (default) keeps a tab inside the session so work can continue in a later turn. Agent-owned unkept tabs close and user-claimed unkept tabs are released.",
       inputSchema: z.object({
         ...sessionFields,
         keep: z.array(z.union([
           z.number().int().positive(),
-          z.object({ tabId: z.number().int().positive(), status: z.enum(["handoff", "deliverable"]).optional().describe("'deliverable' moves the tab to the blue OpenCode Deliverables group; 'handoff' keeps it open ungrouped.") }),
+          z.object({ tabId: z.number().int().positive(), status: z.enum(["handoff", "deliverable"]).optional().describe("'deliverable' moves the tab to the blue OpenCode Deliverables group as a user-facing output; 'handoff' (default) keeps it in the session for later turns.") }),
         ])).max(50).optional(),
         keepEnvironment: z.boolean().optional().describe("Retain applied emulation overrides instead of clearing them."),
       }),

--- a/tests/extension/focus-contract.test.js
+++ b/tests/extension/focus-contract.test.js
@@ -43,7 +43,23 @@ test("finalized deliverables use the dedicated OpenCode group", () => {
   assert.match(extensionSource, /if \(status === "deliverable"\) \{\s*await ensureDeliverableGroup\(tabId\)/);
 });
 
-test("kept tabs default to the blue deliverables group", () => {
-  assert.match(extensionSource, /Number\.isInteger\(item\) \? "deliverable" : item\?\.status \?\? "deliverable"/);
-  assert.match(operationsSource, /status: tool\.schema\.enum\(\["handoff", "deliverable"\]\)\.default\("deliverable"\)/);
+test("kept tabs default to handoff", () => {
+  assert.match(extensionSource, /Number\.isInteger\(item\) \? "handoff" : item\?\.status \?\? "handoff"/);
+  assert.match(operationsSource, /status: tool\.schema\.enum\(\["handoff", "deliverable"\]\)\.default\("handoff"\)/);
+});
+
+test("handoff keeps a tab tracked in the session; only deliverables are untracked", () => {
+  assert.match(
+    extensionSource,
+    /if \(status === "deliverable"\) \{\s*await ensureDeliverableGroup\(tabId\)\.catch\(\(\) => \{\}\);\s*await untrackTab\(id, tabId\);\s*\}/,
+  );
+  const statusBranch = extensionSource.match(/if \(status\) \{[\s\S]*?\n    \}/)?.[0] ?? "";
+  const deliverableBlock = statusBranch.match(/if \(status === "deliverable"\) \{[\s\S]*?\n      \}/)?.[0] ?? "";
+  assert.ok(statusBranch.includes("continue;"));
+  assert.equal((statusBranch.match(/untrackTab/g) ?? []).length, 1);
+  assert.equal((deliverableBlock.match(/untrackTab/g) ?? []).length, 1);
+});
+
+test("unkept agent tabs close tolerantly", () => {
+  assert.match(extensionSource, /await chromeCall\(\(done\) => chrome\.tabs\.remove\(tabId, done\)\)\.catch\(\(\) => \{\}\)/);
 });

--- a/tests/extension/focus-contract.test.js
+++ b/tests/extension/focus-contract.test.js
@@ -42,3 +42,8 @@ test("finalized deliverables use the dedicated OpenCode group", () => {
   assert.match(extensionSource, /group\.title === DELIVERABLE_GROUP_TITLE && group\.windowId === windowId/);
   assert.match(extensionSource, /if \(status === "deliverable"\) \{\s*await ensureDeliverableGroup\(tabId\)/);
 });
+
+test("kept tabs default to the blue deliverables group", () => {
+  assert.match(extensionSource, /Number\.isInteger\(item\) \? "deliverable" : item\?\.status \?\? "deliverable"/);
+  assert.match(operationsSource, /status: tool\.schema\.enum\(\["handoff", "deliverable"\]\)\.default\("deliverable"\)/);
+});


### PR DESCRIPTION
## Summary

Restores the finalize lifecycle of the browser session and keeps the blue **OpenCode Deliverables** group for user-facing outputs.

## Changes

- **Deliverables stay blue and distinct**: tabs kept with status "deliverable" move into the shared blue **OpenCode Deliverables** group and leave session control. The group is discovered by title per window and reused.
- **Handoff lifecycle restored** (the default for a kept tab without an explicit status): the tab remains tracked inside the session's green group, so work can continue in a later turn. The latest mark per tab wins; a handoff must be marked again at the end of a later turn to survive that turn too.
- **Tolerant close**: unkept agent-created tabs close without surfacing tab-close errors; unkept user-claimed tabs are released without closing.
- **Tab-cleanup guidance** (skill, profiles doc, tool schema, MCP ack): never keep research, search, source, intermediate, duplicate, blank, or error pages; deliverables are the live output (documents, dashboards, checkouts, submitted forms, pages the user asked to keep open).
- **Browser selection rules** (skill): an explicit profile request wins over URL-based selection, which wins over the default; discovery stays read-only (no cookies, storage, profiles, passwords); auth-blocked navigation asks the user to sign in instead of bypassing.
- **On-demand troubleshooting** (new docs/troubleshooting.md): topics on discovery and installation, read when setup or connection fails, before retrying.
- Contract tests updated to pin: deliverable to blue group, handoff stays tracked, unkept agent tabs close tolerantly.

## Verification

- `bun run check`: 146 tests, 0 failures.
- Behavior and guidance only; no protocol surface added or removed.
