### PR TITLE
feat: opt-in encrypted Computer History for agent continuity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# The agent-skills spec test requires LF line endings for SKILL.md frontmatter
+skills/**/SKILL.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Performance diagnostics: `browser_observe` mode `diagnostic` records CDP traces and computes LCP, CLS, long tasks, TBT, and more in the native host; raw traces are artifact-first and CrUX/field data stays off.
 - Snowflake-default page search with explicit lexical/auto alternatives and Qwen deep retrieval without loading models in the extension.
 - Profile-aware sessions, tab ownership, stale-target recovery, bounded read retries, conditional settling, approvals, and artifact resources.
+- Opt-in encrypted Computer History (off by default): bounded metadata-only action memory rehydrates continued and recalled sessions with fewer re-exploration mistakes. See [docs/computer-history.md](docs/computer-history.md).
 - MCP stdio and loopback/ authenticated HTTP transports with protocol-clean stdout.
 - A native OpenCode V2 adapter and shared OpenAI, Anthropic, Gemini, and MCP schema adapters.
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -54,6 +54,17 @@ automation bridge:
 You grant or deny these permissions at load time, and you can remove the
 extension at any time.
 
+## Computer History (opt-in, encrypted, local)
+
+Computer History is **off by default**. When you deliberately run
+`opencode-chromium history enable`, the plugin records bounded metadata about
+agent-mediated browser actions (action capability, target hostname, outcome,
+timestamps) into a locally encrypted store. It never records typed text,
+screenshots, raw arguments or results, URLs and paths, window titles, or
+clipboard contents, and no history data ever leaves your machine. You can
+pause, disable, inspect, or cryptographically delete the store and its key at
+any time from the CLI. See [docs/computer-history.md](computer-history.md).
+
 ## Children
 
 This extension is not directed to children, and it does not collect information

--- a/docs/computer-history.md
+++ b/docs/computer-history.md
@@ -1,0 +1,95 @@
+# Computer History
+
+Computer History is an opt-in, encrypted, local record of agent-mediated
+browser actions. It is **off by default** and records only bounded metadata so
+a later agent run can answer: which site was acted on, which action
+capability ran, and whether the outcome was confirmed. This reduces repeated
+page exploration on continuation and recall requests without turning the
+plugin into a screen recorder, keylogger, or telemetry collector.
+
+## Enable or disable
+
+```powershell
+opencode-chromium history enable     # opt in (off by default)
+opencode-chromium history status     # inspect state
+opencode-chromium history pause      # pause capture, keep the store
+opencode-chromium history resume     # resume capture
+opencode-chromium history disable    # stop capture, keep the store
+opencode-chromium history delete --yes  # destroy store and its local key
+```
+
+`history enable` initializes the encrypted store, creates a device-local key,
+and verifies an authenticated write/read self-test before capture starts.
+The CLI prints the stored-field allowlist and the deletion command.
+
+Inspect events locally:
+
+```powershell
+opencode-chromium history list 50     # newest events
+opencode-chromium history show 42     # one event by sequence
+opencode-chromium history status --json
+```
+
+## What is recorded
+
+Only fixed structured metadata:
+
+- event type and timestamp, plus a monotonic per-store sequence;
+- opaque session and action identifiers;
+- one fixed capability enum (for example `browser.tab.create` or
+  `browser.cdp.execute`);
+- the action outcome and delivery categories (confirmed, failed, timeout);
+- an optional application identity: the **hostname** of the page the action
+  targeted (for example `github.com`) when the extension reported it;
+- lifecycle events (enable, disable, pause, resume, session bound, access
+  audit, writer health).
+
+The following are **never** stored: screenshots, typed text, keystrokes,
+clipboard contents, raw tool arguments or results, file paths, window titles,
+full URLs or URL paths, and accessibility trees. There is no plaintext
+fallback and no network I/O for history.
+
+## Storage and encryption
+
+- Default store locations (override with `OPENCODE_BROWSER_HISTORY_DIR`):
+  - Windows: `%LOCALAPPDATA%\opencode-browser-plugin\computer-history`
+  - macOS: `~/Library/Application Support/opencode-browser-plugin/computer-history`
+  - Linux: `${XDG_STATE_HOME:-~/.local/state}/opencode-browser-plugin/computer-history`
+- Records are AES-256-GCM encrypted before they reach disk: one random IV per
+  record plus a per-chunk authenticated file header (no plaintext event data).
+  The 32-byte root key lives in `<root>/key` with user-only permissions (`0600`),
+  and each chunk derives its own key with HKDF-SHA-256.
+- Default retention is 7 days and the default store quota is 100 MiB. Queries
+  never return events older than the retention window; capture is
+  non-blocking and never fails or slows the originating browser action.
+- `delete` is cryptographic: it destroys the key file before removing the
+  encrypted chunks. It does not claim physical erasure from backups, snapshots,
+  or SSD wear leveling.
+
+## Agent access
+
+When enabled, the MCP server and the OpenCode plugin register two read-only
+tools (they are absent when history is disabled):
+
+- `history_status` — availability, encryption, retention, quota, byte usage,
+  dropped-event count, and one fixed health category.
+- `history_query` — a bounded metadata-only event slice (`limit` up to 200,
+  optional `session_id`, `since_sequence`, `until_sequence`). A successful
+  non-empty query appends an encrypted access-audit event.
+
+Agents cannot enable, pause, delete, change retention, or obtain the key
+through these tools. The bundled skill and MCP instructions ask the agent to
+consult history only for continue/resume/recall requests, to treat events as
+leads rather than a transcript, and to continue normally when history is
+unavailable. Results always enter the current model context only.
+
+## Troubleshooting
+
+| Condition | Behavior |
+| --- | --- |
+| `disabled` | Capture is off; earlier encrypted history may remain queryable. |
+| `paused` | Capture (and only capture) is paused; existing history remains. |
+| `storage_corrupt` | A record failed authentication or schema validation; queries stop at that evidence instead of guessing. Use `history delete --yes` to start fresh. |
+| `events_dropped` | The non-blocking capture path dropped events (full queue or quota); treat recent results as possibly incomplete. |
+| `OPENCODE_BROWSER_HISTORY=0` | Forces history tools off even when enabled in the local state file. |
+| `OPENCODE_BROWSER_HISTORY=1` | Forces history tools on for a server process without writing the local state. |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -19,7 +19,7 @@ Options:
 --blocked-origin=PATTERN
 ```
 
-Core mode exposes exactly `browser_run`, `browser_observe`, `browser_session`, and `browser_finalize`. Debug mode adds diagnostics; legacy mode exposes the preserved 52 granular operations for migration and regression testing only.
+Core mode exposes `browser_run`, `browser_observe`, `browser_session`, and `browser_finalize`. When Computer History is enabled (see `docs/computer-history.md`), the read-only `history_status` and `history_query` tools are registered as well. Debug mode adds diagnostics; legacy mode exposes the preserved 52 granular operations for migration and regression testing only.
 
 Origin policy is server-level and never per-call. `--allowed-origin` and `--blocked-origin` accept glob patterns such as `https://*.example.com`; the equivalent environment variables are `AGENT_BROWSER_ALLOWED_ORIGINS` and `AGENT_BROWSER_BLOCKED_ORIGINS` (comma- or semicolon-separated). Blocked origins are rejected at navigation time and, when the Network domain is enabled, at the subresource level through `Network.setBlockedURLs`. Uploads can be restricted to a set of roots with `AGENT_BROWSER_ALLOWED_FILE_ROOTS`.
 

--- a/native-host/src/history/capture.js
+++ b/native-host/src/history/capture.js
@@ -1,0 +1,88 @@
+import { CAPTURED_METHODS, extractHostname, opaqueId } from "./events.js";
+
+function sessionIdFromParams(params) {
+  if (!params || typeof params !== "object") return null;
+  const value = params.session_id ?? params.sessionId ?? params.sessionID;
+  return typeof value === "string" && value.length > 0 && value.length <= 256 ? value : null;
+}
+
+function tabIdFromParams(params) {
+  if (!params || typeof params !== "object") return null;
+  return Number.isInteger(params.tabId) && params.tabId > 0 ? params.tabId : null;
+}
+
+function collectTabUrlPairs(value, out) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectTabUrlPairs(item, out);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (Number.isInteger(value.id) && typeof value.url === "string") out.push({ id: value.id, url: value.url });
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === "object") collectTabUrlPairs(nested, out);
+  }
+}
+
+export class HistoryCapture {
+  constructor({ store }) {
+    this.store = store;
+    this.tabHostnames = new Map();
+  }
+
+  startAgentRequest(message) {
+    const store = this.store;
+    if (!store?.state?.enabled || store.state.paused) return null;
+    const method = message?.method;
+    const capability = CAPTURED_METHODS.get(method);
+    if (!capability || message.id === undefined) return null;
+    const params = message.params ?? {};
+    const sessionId = sessionIdFromParams(params);
+    if (!sessionId) return null;
+    const tabId = tabIdFromParams(params);
+    const application = tabId !== null ? this.applicationFor(tabId) : null;
+    const actionId = opaqueId();
+    store.record({
+      kind: "action_started",
+      sessionId,
+      actionId,
+      capability,
+      application,
+      payload: { kind: "action_started" },
+    });
+    return { actionId, method, sessionId, tabId };
+  }
+
+  completeAgentRequest(capture, outcome, errorCode = null) {
+    if (!capture || !this.store) return;
+    const application = capture.tabId !== null ? this.applicationFor(capture.tabId) : null;
+    this.store.record({
+      kind: "action_completed",
+      sessionId: capture.sessionId,
+      actionId: capture.actionId,
+      capability: CAPTURED_METHODS.get(capture.method) ?? null,
+      application,
+      payload: {
+        kind: "action_completed",
+        effect: outcome,
+        route: "relay",
+        delivery: "foreground",
+        ...(outcome === "failed" ? { error_code: errorCode ?? null } : {}),
+      },
+    });
+  }
+
+  noteResponse(result) {
+    if (!this.store?.state?.enabled) return;
+    const pairs = [];
+    collectTabUrlPairs(result, pairs);
+    for (const { id, url } of pairs) {
+      const hostname = extractHostname(url);
+      if (hostname) this.tabHostnames.set(id, hostname);
+    }
+  }
+
+  applicationFor(tabId) {
+    const hostname = Number.isInteger(tabId) ? this.tabHostnames.get(tabId) : null;
+    return hostname ? { hostname } : null;
+  }
+}

--- a/native-host/src/history/config.js
+++ b/native-host/src/history/config.js
@@ -1,0 +1,119 @@
+import os from "node:os";
+import path from "node:path";
+import { chmodSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+
+const PRODUCT_DIR = "opencode-browser-plugin";
+const HISTORY_DIR = "computer-history";
+
+export const HISTORY_ENV_DIR = "OPENCODE_BROWSER_HISTORY_DIR";
+export const HISTORY_ENV_FORCE = "OPENCODE_BROWSER_HISTORY";
+export const RETENTION_DAYS = 7;
+export const QUOTA_BYTES = 100 * 1024 * 1024;
+export const MAX_QUERY_EVENTS = 200;
+export const DEFAULT_QUERY_EVENTS = 50;
+export const WRITER_QUEUE_CAPACITY = 512;
+export const WRITER_FLUSH_MS = 500;
+export const WRITER_SEAL_BYTES = 8 * 1024 * 1024;
+export const WRITER_SEAL_HOURS_MS = 60 * 60 * 1000;
+export const STORAGE_PROFILE = "opencode-browser-plugin-history-v1/aes-256-gcm+jsonl+cloudevents-json";
+export const EVENT_SCHEMA = "urn:opencode-browser-plugin:schema:history-event:v0";
+
+export function historyRootDir() {
+  if (process.env[HISTORY_ENV_DIR]) return path.resolve(process.env[HISTORY_ENV_DIR]);
+  if (process.platform === "win32") {
+    const base = process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+    return path.join(base, PRODUCT_DIR, HISTORY_DIR);
+  }
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", PRODUCT_DIR, HISTORY_DIR);
+  }
+  const base = process.env.XDG_STATE_HOME ?? path.join(os.homedir(), ".local", "state");
+  return path.join(base, PRODUCT_DIR, HISTORY_DIR);
+}
+
+export function stateFilePath(root) {
+  return path.join(root, "state.json");
+}
+
+export function keyFilePath(root) {
+  return path.join(root, "key");
+}
+
+export function lockFilePath(root) {
+  return path.join(root, "writer.lock");
+}
+
+export function chunkDir(root) {
+  return path.join(root, "chunks");
+}
+
+export function defaultState() {
+  return { enabled: false, paused: false, sequence: 0, dropped: 0, corrupt: false, admitted: false, createdAt: null };
+}
+
+export function readState(root) {
+  try {
+    const parsed = JSON.parse(readFileSync(stateFilePath(root), "utf8"));
+    if (!parsed || typeof parsed !== "object") return defaultState();
+    return {
+      enabled: parsed.enabled === true,
+      paused: parsed.paused === true,
+      sequence: Number.isInteger(parsed.sequence) && parsed.sequence > 0 ? parsed.sequence : 0,
+      dropped: Number.isInteger(parsed.dropped) && parsed.dropped > 0 ? parsed.dropped : 0,
+      corrupt: parsed.corrupt === true,
+      admitted: parsed.admitted === true,
+      createdAt: typeof parsed.createdAt === "string" ? parsed.createdAt : null,
+    };
+  } catch {
+    return defaultState();
+  }
+}
+
+export function writeState(root, state) {
+  mkdirSync(root, { recursive: true });
+  const tmp = stateFilePath(root) + ".tmp";
+  writeFileSync(tmp, JSON.stringify(state, null, 2), "utf8");
+  renameSync(tmp, stateFilePath(root));
+}
+
+export function ensurePrivateDir(dir) {
+  mkdirSync(dir, { recursive: true });
+  if (process.platform !== "win32") {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // best effort; documented as a non-Windows hardening step
+    }
+  }
+}
+
+export function chunkFiles(root) {
+  const dir = chunkDir(root);
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".chunk"))
+      .map((name) => path.join(dir, name))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export function chunkBytes(root) {
+  let total = 0;
+  for (const file of chunkFiles(root)) {
+    try {
+      total += statSync(file).size;
+    } catch {
+      // skip missing file
+    }
+  }
+  return total;
+}
+
+export function historyEnabledForServer() {
+  const force = process.env[HISTORY_ENV_FORCE];
+  if (force === "1") return true;
+  if (force === "0") return false;
+  return readState(historyRootDir()).enabled === true;
+}

--- a/native-host/src/history/crypto.js
+++ b/native-host/src/history/crypto.js
@@ -1,0 +1,60 @@
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "node:crypto";
+import { chmodSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const KEY_INFO = "opencode-browser-plugin/history/v1/chunk-key";
+const KEY_FILE_PERMS = 0o600;
+
+export function loadOrCreateRootKey(root) {
+  const keyFile = path.join(root, "key");
+  try {
+    const existing = readFileSync(keyFile);
+    if (existing.length === KEY_BYTES) return existing;
+  } catch {
+    // no key yet; create below
+  }
+  const key = randomBytes(KEY_BYTES);
+  writeFileSync(keyFile, key, { mode: KEY_FILE_PERMS });
+  try {
+    chmodSync(keyFile, KEY_FILE_PERMS);
+  } catch {
+    // Windows ignores POSIX modes
+  }
+  return key;
+}
+
+export function destroyRootKey(root) {
+  rmSync(path.join(root, "key"), { force: true });
+}
+
+export function chunkKey(rootKey, chunkId) {
+  return hkdfSync("sha256", rootKey, Buffer.from(chunkId, "utf8"), Buffer.from(KEY_INFO, "utf8"), KEY_BYTES);
+}
+
+export function encryptRecord(key, aad, plaintext) {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.from(aad, "utf8"));
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return {
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+    ct: ciphertext.toString("base64"),
+  };
+}
+
+export function decryptRecord(key, aad, record) {
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(record.iv, "base64"));
+  decipher.setAAD(Buffer.from(aad, "utf8"));
+  decipher.setAuthTag(Buffer.from(record.tag, "base64"));
+  return Buffer.concat([decipher.update(Buffer.from(record.ct, "base64")), decipher.final()]).toString("utf8");
+}
+
+export function selfTestKey(root) {
+  const key = loadOrCreateRootKey(root);
+  const aad = "self-test";
+  const roundtrip = decryptRecord(key, aad, encryptRecord(key, aad, "opencode-browser-plugin history self-test"));
+  return roundtrip === "opencode-browser-plugin history self-test" ? key : null;
+}

--- a/native-host/src/history/events.js
+++ b/native-host/src/history/events.js
@@ -1,0 +1,109 @@
+import { createHash, randomBytes } from "node:crypto";
+import { EVENT_SCHEMA } from "./config.js";
+
+export const CAPTURED_METHODS = new Map([
+  ["createTab", "browser.tab.create"],
+  ["claimUserTab", "browser.tab.claim"],
+  ["closeTab", "browser.tab.close"],
+  ["releaseTab", "browser.tab.release"],
+  ["reloadTab", "browser.tab.reload"],
+  ["activateTab", "browser.tab.activate"],
+  ["executeCdp", "browser.cdp.execute"],
+  ["inputGesture", "browser.input.gesture"],
+  ["moveMouse", "browser.pointer.move"],
+  ["finalizeTabs", "browser.session.finalize"],
+  ["turnEnded", "browser.session.turn_end"],
+  ["nameSession", "browser.session.name"],
+]);
+
+export const HEALTH_CATEGORIES = new Set([
+  "ready",
+  "disabled",
+  "paused",
+  "key_unavailable",
+  "storage_unavailable",
+  "storage_corrupt",
+  "quota_reached",
+  "events_dropped",
+  "writer_stopped",
+]);
+
+export function eventType(kind) {
+  return `opencode-browser-plugin.history.${kind}.v0`;
+}
+
+export function opaqueId() {
+  return randomBytes(16).toString("hex");
+}
+
+export function storeIdentifier(root) {
+  return createHash("sha256").update(root).digest("hex").slice(0, 32);
+}
+
+export function extractHostname(url) {
+  if (typeof url !== "string" || url.length === 0 || url.length > 4096) return null;
+  if (/^(chrome|edge|brave|vivaldi|opera|chrome-extension|about|data|blob|file):/i.test(url)) return null;
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname?.toLowerCase();
+    if (!hostname) return null;
+    return hostname.length <= 255 ? hostname : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeHostname(value) {
+  if (typeof value !== "string") return null;
+  const hostname = value.toLowerCase();
+  if (hostname.length === 0 || hostname.length > 255) return null;
+  if (/[\s\\/]/.test(hostname)) return null;
+  return hostname;
+}
+
+let sourceByRoot = new Map();
+
+export function sourceFor(root) {
+  if (!sourceByRoot.has(root)) sourceByRoot.set(root, `urn:opencode-browser-plugin:history:${storeIdentifier(root)}`);
+  return sourceByRoot.get(root);
+}
+
+export function buildEvent({ root, sequence, kind, sessionId = null, actionId = null, capability = null, callerCategory = "agent_runtime", application = null, payload = null }) {
+  const subject = kind === "session_started" || kind === "session_ended"
+    ? `session/${sessionId ?? "?"}`
+    : kind === "action_started" || kind === "action_completed"
+      ? `action/${actionId ?? "?"}`
+      : `history/${opaqueId()}`;
+  const data = {
+    sequence,
+    platform: process.platform,
+    process_model: "in_native_host",
+    caller_category: callerCategory,
+    ...(sessionId ? { session_id: sessionId } : {}),
+    ...(actionId ? { action_id: actionId } : {}),
+    ...(capability ? { capability } : {}),
+    ...(application ? { application } : {}),
+    payload: payload ?? { kind },
+  };
+  return {
+    specversion: "1.0",
+    id: opaqueId(),
+    source: sourceFor(root),
+    type: eventType(kind),
+    subject,
+    time: new Date().toISOString(),
+    datacontenttype: "application/json",
+    dataschema: EVENT_SCHEMA,
+    data,
+  };
+}
+
+export function actionPayload({ status }) {
+  if (status === "completed") {
+    return { kind: "action_completed", effect: "confirmed", route: "relay", delivery: "foreground" };
+  }
+  if (status === "failed") {
+    return { kind: "action_completed", effect: "failed", route: "relay", delivery: "foreground" };
+  }
+  return { kind: "action_started" };
+}

--- a/native-host/src/history/index.js
+++ b/native-host/src/history/index.js
@@ -1,0 +1,33 @@
+export {
+  HISTORY_ENV_DIR,
+  HISTORY_ENV_FORCE,
+  RETENTION_DAYS,
+  QUOTA_BYTES,
+  MAX_QUERY_EVENTS,
+  DEFAULT_QUERY_EVENTS,
+  STORAGE_PROFILE,
+  EVENT_SCHEMA,
+  WRITER_QUEUE_CAPACITY,
+  historyRootDir,
+  readState,
+  writeState,
+  defaultState,
+  chunkFiles,
+  chunkBytes,
+  historyEnabledForServer,
+  ensurePrivateDir,
+} from "./config.js";
+export {
+  CAPTURED_METHODS,
+  HEALTH_CATEGORIES,
+  eventType,
+  opaqueId,
+  storeIdentifier,
+  extractHostname,
+  normalizeHostname,
+  buildEvent,
+  actionPayload,
+} from "./events.js";
+export { loadOrCreateRootKey, destroyRootKey, chunkKey, encryptRecord, decryptRecord, selfTestKey } from "./crypto.js";
+export { HistoryStore, historyHealth, withHistoryLock } from "./store.js";
+export { HistoryCapture } from "./capture.js";

--- a/native-host/src/history/store.js
+++ b/native-host/src/history/store.js
@@ -1,0 +1,420 @@
+import { closeSync, fsyncSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeSync } from "node:fs";
+import path from "node:path";
+import {
+  DEFAULT_QUERY_EVENTS,
+  EVENT_SCHEMA,
+  MAX_QUERY_EVENTS,
+  QUOTA_BYTES,
+  RETENTION_DAYS,
+  STORAGE_PROFILE,
+  WRITER_FLUSH_MS,
+  WRITER_QUEUE_CAPACITY,
+  WRITER_SEAL_BYTES,
+  WRITER_SEAL_HOURS_MS,
+  chunkBytes,
+  chunkDir,
+  chunkFiles,
+  defaultState,
+  ensurePrivateDir,
+  historyRootDir,
+  lockFilePath,
+  readState,
+  stateFilePath,
+  writeState,
+} from "./config.js";
+import { chunkKey, decryptRecord, destroyRootKey, encryptRecord, loadOrCreateRootKey } from "./crypto.js";
+import { buildEvent, opaqueId } from "./events.js";
+
+const AAD_PROFILE = "opencode-browser-plugin/history/v1/aad";
+const LOCK_WAIT_MS = 5000;
+const LOCK_RETRY_MS = 75;
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function waitForLock(root) {
+  const lockPath = lockFilePath(root);
+  const started = Date.now();
+  for (;;) {
+    try {
+      return openSync(lockPath, "wx", 0o600);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (Date.now() - started > LOCK_WAIT_MS) {
+        throw new Error("Another history operation is in progress; retry shortly.");
+      }
+      const wait = Date.now() + LOCK_RETRY_MS;
+      while (Date.now() < wait) {
+        // local utility lock; brief busy wait is acceptable
+      }
+    }
+  }
+}
+
+export async function withHistoryLock(root, fn) {
+  const fd = waitForLock(root);
+  try {
+    return await fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } finally {
+      rmSync(lockFilePath(root), { force: true });
+    }
+  }
+}
+
+export function historyHealth(state, { writerAlive = false } = {}) {
+  if (state.corrupt) return "storage_corrupt";
+  if (!state.enabled) return "disabled";
+  if (state.paused) return "paused";
+  if (state.dropped > 0) return "events_dropped";
+  if (!writerAlive) return "writer_stopped";
+  return "ready";
+}
+
+export class HistoryStore {
+  constructor({ root } = {}) {
+    this.root = root ?? historyRootDir();
+    this.queue = [];
+    this.closed = false;
+    this.writerTimer = null;
+    this.openChunk = null;
+    this.lastSealAt = Date.now();
+    this.writerAlive = false;
+    ensurePrivateDir(this.root);
+    ensurePrivateDir(chunkDir(this.root));
+    this.state = readState(this.root);
+    this.stateLoadedAt = Date.now();
+  }
+
+  loadState() {
+    this.state = readState(this.root);
+    this.stateLoadedAt = Date.now();
+    return this.state;
+  }
+
+  refreshState() {
+    if (this.stateLoadedAt && Date.now() - this.stateLoadedAt < 2000) return this.state;
+    return this.loadState();
+  }
+
+  persistState() {
+    this.stateLoadedAt = Date.now();
+    writeState(this.root, this.state);
+  }
+
+  #nextSequence() {
+    this.state.sequence += 1;
+    return this.state.sequence;
+  }
+
+  #enqueue(event) {
+    if (this.queue.length >= WRITER_QUEUE_CAPACITY) {
+      this.state.dropped += 1;
+      this.persistState();
+      return false;
+    }
+    this.queue.push(event);
+    if (this.queue.length >= 64) this.flushSync();
+    return true;
+  }
+
+  record({ kind, sessionId = null, actionId = null, capability = null, callerCategory = "agent_runtime", application = null, payload = null }) {
+    this.refreshState();
+    if (!this.state.enabled || this.state.paused) return { accepted: false, reason: this.state.paused ? "paused" : "disabled" };
+    const event = buildEvent({
+      root: this.root,
+      sequence: this.#nextSequence(),
+      kind,
+      sessionId,
+      actionId,
+      capability,
+      callerCategory,
+      application,
+      payload,
+    });
+    this.persistState();
+    return { accepted: this.#enqueue(event), event };
+  }
+
+  startWriter() {
+    if (this.writerTimer || this.closed) return;
+    this.writerAlive = true;
+    this.writerTimer = setInterval(() => this.flushSync(), WRITER_FLUSH_MS);
+    if (this.writerTimer.unref) this.writerTimer.unref();
+  }
+
+  stopWriter() {
+    if (this.writerTimer) {
+      clearInterval(this.writerTimer);
+      this.writerTimer = null;
+    }
+    this.flushSync();
+    this.sealChunk();
+    this.writerAlive = false;
+  }
+
+  #openChunkFile() {
+    const dir = chunkDir(this.root);
+    const chunkId = opaqueId();
+    const created = Date.now();
+    const header = JSON.stringify({ v: 1, profile: STORAGE_PROFILE, chunkId, created: isoNow(), sealed: false });
+    const file = path.join(dir, `${created}-${chunkId}.chunk`);
+    const fd = openSync(file, "a", 0o600);
+    writeSync(fd, `${header}\n`, null, "utf8");
+    return { chunkId, file, fd };
+  }
+
+  sealChunk() {
+    if (!this.openChunk) return;
+    try {
+      fsyncSync(this.openChunk.fd);
+    } catch {
+      // best effort
+    }
+    try {
+      closeSync(this.openChunk.fd);
+    } catch {
+      // already closed
+    }
+    this.openChunk = null;
+  }
+
+  flushSync() {
+    if (this.closed || this.queue.length === 0) return;
+    const batch = this.queue;
+    this.queue = [];
+    if (this.state.corrupt) {
+      this.state.dropped += batch.length;
+      this.persistState();
+      return;
+    }
+    if (chunkBytes(this.root) + batch.length * 256 >= QUOTA_BYTES) {
+      this.state.dropped += batch.length;
+      this.persistState();
+      return;
+    }
+    try {
+      if (!this.openChunk) this.openChunk = this.#openChunkFile();
+      const rootKey = loadOrCreateRootKey(this.root);
+      const key = chunkKey(rootKey, this.openChunk.chunkId);
+      const aad = JSON.stringify({ profile: AAD_PROFILE, chunkId: this.openChunk.chunkId });
+      const lines = batch.map((event) => JSON.stringify(encryptRecord(key, aad, JSON.stringify(event))));
+      if (statSync(this.openChunk.file).size > WRITER_SEAL_BYTES) this.sealChunk();
+      if (!this.openChunk) this.openChunk = this.#openChunkFile();
+      for (const line of lines) {
+        writeSync(this.openChunk.fd, `${line}\n`, null, "utf8");
+      }
+      if (Date.now() - this.lastSealAt >= WRITER_SEAL_HOURS_MS) {
+        this.sealChunk();
+        this.lastSealAt = Date.now();
+      }
+      this.pruneExpired();
+    } catch {
+      this.state.corrupt = true;
+      this.persistState();
+    }
+  }
+
+  pruneExpired(now = Date.now()) {
+    const cutoff = now - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    for (const file of chunkFiles(this.root)) {
+      if (!readChunk(file).ok) continue;
+      if (chunkFileMtime(file) < cutoff) rmSync(file, { force: true });
+    }
+  }
+
+  *readEvents({ now = Date.now() } = {}) {
+    const rootKey = loadOrCreateRootKey(this.root);
+    const cutoff = now - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    if (!rootKey) return;
+    for (const file of chunkFiles(this.root)) {
+      const chunk = readChunk(file);
+      if (!chunk.ok) return;
+      const key = chunkKey(rootKey, chunk.header.chunkId);
+      const aad = JSON.stringify({ profile: AAD_PROFILE, chunkId: chunk.header.chunkId });
+      const lines = chunk.body;
+      for (let index = 0; index < lines.length; index += 1) {
+        let event = null;
+        try {
+          event = JSON.parse(decryptRecord(key, aad, JSON.parse(lines[index])));
+        } catch {
+          const isTail = index === lines.length - 1 && chunk.header.sealed !== true;
+          if (isTail) return;
+          yield { corrupt: "unauthenticated or malformed record in history chunk" };
+          return;
+        }
+        if (!event?.data || event.dataschema !== EVENT_SCHEMA) {
+          yield { corrupt: "unsupported history event schema" };
+          return;
+        }
+        const at = Date.parse(event.time);
+        if (!Number.isFinite(at) || at < cutoff) continue;
+        yield event;
+      }
+    }
+  }
+
+  list({ limit = DEFAULT_QUERY_EVENTS } = {}) {
+    const bound = Number.isInteger(limit) ? Math.min(Math.max(limit, 1), MAX_QUERY_EVENTS) : DEFAULT_QUERY_EVENTS;
+    const collected = [];
+    for (const event of this.readEvents()) {
+      if (event?.corrupt) break;
+      collected.push(event);
+    }
+    return { events: collected.slice(-bound), metadata_only: true };
+  }
+
+  show(sequence) {
+    if (!Number.isInteger(sequence) || sequence < 1) return { event: null };
+    for (const event of this.readEvents()) {
+      if (event?.corrupt) break;
+      if (event.data?.sequence === sequence) return { event };
+    }
+    return { event: null };
+  }
+
+  query({ limit = DEFAULT_QUERY_EVENTS, sessionId = null, sinceSequence = null, untilSequence = null } = {}) {
+    const bound = Number.isInteger(limit) ? Math.min(Math.max(limit, 1), MAX_QUERY_EVENTS) : DEFAULT_QUERY_EVENTS;
+    let healthWarning = null;
+    const collected = [];
+    for (const event of this.readEvents()) {
+      if (event?.corrupt) {
+        healthWarning = event.corrupt;
+        break;
+      }
+      const seq = event.data?.sequence;
+      if (sinceSequence !== null && seq < sinceSequence) continue;
+      if (untilSequence !== null && seq > untilSequence) continue;
+      if (sessionId && event.data?.session_id !== sessionId) continue;
+      collected.push(event);
+    }
+    const events = collected.slice(-bound);
+    if (events.length > 0 && !healthWarning) {
+      this.record({
+        kind: "access",
+        callerCategory: "agent_runtime",
+        payload: { kind: "access", operation: "agent_query", returned: events.length },
+      });
+    }
+    return {
+      events,
+      metadata_only: true,
+      model_context_disclosure: true,
+      ...(healthWarning ? { health_warning: healthWarning } : {}),
+    };
+  }
+
+  status() {
+    return {
+      supported: true,
+      admitted: this.state.admitted,
+      enabled: this.state.enabled,
+      paused: this.state.paused,
+      encrypted: true,
+      profile: STORAGE_PROFILE,
+      retention_days: RETENTION_DAYS,
+      quota_bytes: QUOTA_BYTES,
+      bytes_used: chunkBytes(this.root),
+      dropped_events: this.state.dropped,
+      health: historyHealth(this.state, { writerAlive: this.writerAlive }),
+    };
+  }
+
+  enable() {
+    this.loadState();
+    this.state.admitted = true;
+    this.state.enabled = true;
+    this.state.paused = false;
+    this.state.corrupt = false;
+    this.persistState();
+    if (!selfTestBytes(this.root)) {
+      this.state.enabled = false;
+      this.persistState();
+      throw new Error("History encryption self-test failed; capture stays disabled.");
+    }
+    this.record({ kind: "control", payload: { kind: "control", operation: "enable" } });
+    this.flushSync();
+    this.startWriter();
+    return this.status();
+  }
+
+  disable() {
+    this.record({ kind: "control", payload: { kind: "control", operation: "disable" } });
+    this.flushSync();
+    this.stopWriter();
+    this.loadState();
+    this.state.enabled = false;
+    this.state.paused = false;
+    this.persistState();
+    return this.status();
+  }
+
+  pause() {
+    this.record({ kind: "control", payload: { kind: "control", operation: "pause" } });
+    this.flushSync();
+    this.stopWriter();
+    this.loadState();
+    this.state.paused = true;
+    this.persistState();
+    return this.status();
+  }
+
+  resume() {
+    this.loadState();
+    this.state.paused = false;
+    this.persistState();
+    this.record({ kind: "control", payload: { kind: "control", operation: "resume" } });
+    this.flushSync();
+    return this.status();
+  }
+
+  hardDelete() {
+    this.stopWriter();
+    destroyRootKey(this.root);
+    const dir = chunkDir(this.root);
+    try {
+      for (const name of readdirSync(dir)) rmSync(path.join(dir, name), { force: true });
+      rmSync(dir, { force: true, recursive: true });
+    } catch {
+      // directory absent
+    }
+    rmSync(stateFilePath(this.root), { force: true });
+    this.state = defaultState();
+    return { deleted: true, message: "History store and its encryption key were deleted." };
+  }
+
+  close() {
+    this.closed = true;
+    this.stopWriter();
+  }
+}
+
+function chunkFileMtime(file) {
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function readChunk(file) {
+  try {
+    const raw = readFileSync(file, "utf8");
+    const lines = raw.split("\n").filter((line) => line.trim() !== "");
+    const header = JSON.parse(lines[0]);
+    if (!header?.chunkId || header.profile !== STORAGE_PROFILE) return { ok: false };
+    return { ok: true, header, body: lines.slice(1) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function selfTestBytes(root) {
+  const key = loadOrCreateRootKey(root);
+  const record = encryptRecord(key, "self-test", "opencode-browser-plugin history self-test");
+  const back = decryptRecord(key, "self-test", record);
+  return back === "opencode-browser-plugin history self-test";
+}

--- a/native-host/src/host.js
+++ b/native-host/src/host.js
@@ -7,6 +7,7 @@ import { FrameDecoder, writeFrame } from "./framing.js";
 import { instanceIpcPath, isUnixSocketPath } from "./ipc-path.js";
 import { removeProfileRegistration, writeProfileRegistration } from "./profile-registry.js";
 import { RpcRelay } from "./rpc-relay.js";
+import { HistoryCapture, HistoryStore } from "./history/index.js";
 import { handleSemanticHostMethod } from "./semantic-search.js";
 import { handleVisualHostMethod } from "./visual-map.js";
 import { handleDiagnosticsHostMethod } from "./diagnostics/index.js";
@@ -17,6 +18,9 @@ const PROTOCOL_VERSION = "1";
 const ipcPath = instanceIpcPath();
 const state = { startedAt: new Date().toISOString(), ipcPath, profile: null };
 let activeProfileId = null;
+
+const historyStore = new HistoryStore();
+const historyCapture = new HistoryCapture({ store: historyStore });
 
 function registerProfile(profile) {
   if (activeProfileId && activeProfileId !== profile.profileId) {
@@ -44,6 +48,7 @@ const relay = new RpcRelay({
   state,
   extensionWriter: (message) => writeFrame(process.stdout, message),
   onProfile: registerProfile,
+  history: historyCapture,
   localHandler: async (method, params) => {
     const semantic = await handleSemanticHostMethod(method, params);
     if (semantic !== undefined) return semantic;
@@ -112,6 +117,8 @@ function shutdownHost(reason, exitCode = 0) {
   if (shutdownStarted) return;
   shutdownStarted = true;
   log(reason);
+  relay.flushHistory();
+  historyStore.close();
   cleanupProfileRegistration();
   relay.shutdown(reason);
   server.close(() => {

--- a/native-host/src/rpc-relay.js
+++ b/native-host/src/rpc-relay.js
@@ -17,12 +17,18 @@ export class RpcRelay {
   #state;
   #onProfile;
   #localHandler;
+  #history;
 
-  constructor({ extensionWriter, state, onProfile, localHandler }) {
+  constructor({ extensionWriter, state, onProfile, localHandler, history = null }) {
     this.#extensionWriter = extensionWriter;
     this.#state = state;
     this.#onProfile = onProfile;
     this.#localHandler = localHandler;
+    this.#history = history;
+  }
+
+  flushHistory() {
+    this.#history?.flush?.();
   }
 
   addClient(socket) {
@@ -96,14 +102,19 @@ export class RpcRelay {
       }
 
       const extensionId = this.#nextRequestId++;
+      const capture = this.#history?.startAgentRequest(message) ?? null;
       const timeout = setTimeout(() => {
         const pending = this.#deletePending(extensionId);
-        if (pending) void this.#writeClientError(pending.socket, pending.clientId, -32000, `Timed out waiting for extension response to ${message.method}`);
+        if (pending) {
+          this.#history?.completeAgentRequest?.(pending.capture, "failed", "timeout");
+          void this.#writeClientError(pending.socket, pending.clientId, -32000, `Timed out waiting for extension response to ${message.method}`);
+        }
       }, requestTimeoutMs(message));
       this.#setPending(extensionId, {
         clientId: message.id,
         socket,
         timeout,
+        capture,
       });
       try {
         await this.#extensionWriter({ ...message, id: extensionId });
@@ -179,6 +190,15 @@ export class RpcRelay {
   async #handleExtensionResponse(message) {
     const pending = this.#deletePending(message.id);
     if (!pending) return;
+    this.#history?.noteResponse?.(message.result);
+    if (pending.capture) {
+      const error = message.error?.data && typeof message.error.data === "object" && typeof message.error.data.code === "string"
+        ? message.error.data.code
+        : typeof message.error?.code === "number"
+          ? `rpc-${message.error.code}`
+          : null;
+      this.#history?.completeAgentRequest?.(pending.capture, message.error ? "failed" : "confirmed", error);
+    }
     await writeFrame(pending.socket, { ...message, id: pending.clientId });
   }
 

--- a/skills/opencode-browser-plugin/SKILL.md
+++ b/skills/opencode-browser-plugin/SKILL.md
@@ -37,6 +37,16 @@ Apply persistent test environments with `browser_session` action `configure` —
 
 Record local performance traces through `browser_observe` mode `diagnostic` with `diagnostic.type: "performance"` and `action: "record"`; the raw trace is stored as an artifact and the summary returns LCP, CLS, long tasks, blocking time, and more. Re-analyze a stored trace with `action: "inspect"`. Performance analysis is local-only: field data (CrUX) is never consulted.
 
+## Computer History
+
+When the user asks you to continue, resume, recall recent browser activity, or pick up a prior browser session, consult Computer History before re-exploring the page:
+
+1. Call `history_status` first and preserve any disabled, paused, or unhealthy state in your reasoning.
+2. When useful and authorized, call `history_query` once with a bounded recent slice (`limit`, optionally `session_id`) before broader page discovery.
+3. Treat returned events as metadata-only leads — which site, which action capability, and whether the outcome was confirmed — then verify the current live state through the least intrusive appropriate step.
+4. History never includes URLs, paths, typed text, arguments, or results: treat omitted content as unknown and never reconstruct it.
+5. Continue normally after absence, denial, empty results, or a recoverable history failure; do not query history for unrelated tasks merely because the tools exist.
+
 ```json
 {
   "profile": "Work",

--- a/src/adapters/mcp/server.js
+++ b/src/adapters/mcp/server.js
@@ -21,6 +21,7 @@ import { artifactUriTemplate } from "../../core/artifacts.js";
 import { contractMetadata, PLUGIN_NAME, PLUGIN_VERSION } from "../../core/versions.js";
 import { createBrowserOperations } from "../../browser/operations/index.js";
 import { closeBrowserClients } from "../../browser/client.js";
+import { historyEnabledForServer } from "../../history/index.js";
 
 export const SERVER_NAME = PLUGIN_NAME;
 export const SERVER_INSTRUCTIONS = [
@@ -29,6 +30,7 @@ export const SERVER_INSTRUCTIONS = [
   "Page search uses Snowflake by default; request lexical or auto for lower-latency retrieval, and deep for genuinely semantic, multilingual, or code-heavy matching.",
   "For a specific tab's deeper network debugging, request browser_observe mode capabilities with pack network, then execute network.inspect inside browser_run; bodies are opt-in and approval-gated.",
   "Approval-required results must be followed by browser_run with only the approvalToken. Call browser_finalize when finished.",
+  "When asked to continue, resume, or recall what a prior browser run did, check history_status and then one bounded history_query before re-exploring; treat events as metadata-only leads (site, capability, outcome), never as a transcript.",
 ].join(" ");
 
 function rootDir() {
@@ -115,8 +117,8 @@ function mcpSchema(schema) {
   };
 }
 
-export async function registerCoreTools(server, runtime, fallbackSessionId) {
-  const registry = createCoreRegistry(runtime);
+export async function registerCoreTools(server, runtime, fallbackSessionId, { history = false } = {}) {
+  const registry = createCoreRegistry(runtime, { history });
   for (const [name, definition] of Object.entries(registry)) {
     server.registerTool(name, {
       description: definition.description,
@@ -176,9 +178,9 @@ export async function registerLegacyTools(server, fallbackSessionId) {
   }
 }
 
-export async function createServer({ runtime, toolset = "core", fallbackSessionId = `mcp-${randomUUID()}` } = {}) {
+export async function createServer({ runtime, toolset = "core", fallbackSessionId = `mcp-${randomUUID()}`, history = historyEnabledForServer() } = {}) {
   const server = new McpServer({ name: SERVER_NAME, version: packageVersion() }, { instructions: SERVER_INSTRUCTIONS });
-  if (toolset === "core" || toolset === "debug") await registerCoreTools(server, runtime ?? createAgentBrowserRuntime(), fallbackSessionId);
+  if (toolset === "core" || toolset === "debug") await registerCoreTools(server, runtime ?? createAgentBrowserRuntime(), fallbackSessionId, { history });
   if (toolset === "legacy" || toolset === "debug") await registerLegacyTools(server, fallbackSessionId);
   return server;
 }

--- a/src/adapters/opencode/index.js
+++ b/src/adapters/opencode/index.js
@@ -5,6 +5,7 @@ import { createCoreRegistry } from "../../core/registry.js";
 import { dispatchBrowserTool, jsonSchemaFor } from "../../core/schema-adapters.js";
 import { contractMetadata, PLUGIN_NAME, PLUGIN_VERSION } from "../../core/versions.js";
 import { createLogger } from "../../core/logging.js";
+import { historyEnabledForServer } from "../../history/index.js";
 
 function concise(result) {
   const text = JSON.stringify(result);
@@ -64,7 +65,7 @@ function legacyTool(name, definition, runtime) {
 
 function createLegacyOpenCodeHooks(options = {}) {
   const runtime = options.runtime ?? createAgentBrowserRuntime(options);
-  const registry = createCoreRegistry(runtime);
+  const registry = createCoreRegistry(runtime, { history: options.history ?? historyEnabledForServer() });
   const tools = Object.fromEntries(Object.entries(registry).map(([name, definition]) => [name, legacyTool(name, definition, runtime)]));
   let disposed = false;
   return {
@@ -91,7 +92,7 @@ async function registerWithContext(ctx, name, tool) {
 
 export async function createOpenCodeSetup(ctx = {}, options = {}) {
   const runtime = options.runtime ?? ctx.runtime ?? createAgentBrowserRuntime(options);
-  const registry = createCoreRegistry(runtime);
+  const registry = createCoreRegistry(runtime, { history: options.history ?? historyEnabledForServer() });
   const tools = Object.fromEntries(Object.entries(registry).map(([name, definition]) => [name, nativeTool(name, definition, runtime)]));
   const logger = options.logger ?? ctx.logger ?? createLogger({ name: PLUGIN_NAME, sink: process.stderr });
   for (const [name, tool] of Object.entries(tools)) {

--- a/src/adapters/sdk/index.js
+++ b/src/adapters/sdk/index.js
@@ -4,7 +4,7 @@ import { dispatchBrowserTool, toolDefinitionsForDialect } from "../../core/schem
 
 export function createBrowserAgent(options = {}) {
   const runtime = options.runtime ?? createAgentBrowserRuntime(options);
-  const registry = createCoreRegistry(runtime);
+  const registry = createCoreRegistry(runtime, { history: options.history ?? false });
   return {
     runtime,
     registry,

--- a/src/cli/history.js
+++ b/src/cli/history.js
@@ -1,0 +1,138 @@
+import process from "node:process";
+import {
+  DEFAULT_QUERY_EVENTS,
+  HistoryStore,
+  MAX_QUERY_EVENTS,
+  historyRootDir,
+  withHistoryLock,
+} from "../history/index.js";
+
+function parseLimit(value) {
+  if (value === undefined) return DEFAULT_QUERY_EVENTS;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_QUERY_EVENTS) {
+    throw new Error(`Limit must be an integer between 1 and ${MAX_QUERY_EVENTS}.`);
+  }
+  return parsed;
+}
+
+function parseSequence(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error("Sequence must be a positive integer.");
+  return parsed;
+}
+
+function commandUsage(command) {
+  return {
+    enable: "opencode-chromium history enable [--json]",
+    disable: "opencode-chromium history disable [--json]",
+    pause: "opencode-chromium history pause [--json]",
+    resume: "opencode-chromium history resume [--json]",
+    status: "opencode-chromium history status [--json]",
+    list: "opencode-chromium history list [limit] [--json]",
+    show: "opencode-chromium history show <sequence> [--json]",
+    delete: "opencode-chromium history delete --yes [--json]",
+  }[command];
+}
+
+export async function runHistoryCommand(argv) {
+  const [subcommand = "status", ...rest] = argv;
+  const json = rest.includes("--json");
+  const root = historyRootDir();
+  const store = new HistoryStore({ root });
+  let result;
+
+  switch (subcommand) {
+    case "enable": {
+      result = await withHistoryLock(root, () => store.enable());
+      break;
+    }
+    case "disable": {
+      result = await withHistoryLock(root, () => store.disable());
+      break;
+    }
+    case "pause": {
+      result = await withHistoryLock(root, () => store.pause());
+      break;
+    }
+    case "resume": {
+      result = await withHistoryLock(root, () => store.resume());
+      break;
+    }
+    case "status": {
+      result = store.status();
+      break;
+    }
+    case "list": {
+      const limitValue = rest.find((arg) => !arg.startsWith("--"));
+      result = store.list({ limit: parseLimit(limitValue) });
+      break;
+    }
+    case "show": {
+      const sequence = rest.find((arg) => !arg.startsWith("--"));
+      if (!sequence) throw new Error("history show requires a sequence number.\nUsage: " + commandUsage("show"));
+      result = store.show(parseSequence(sequence));
+      break;
+    }
+    case "delete": {
+      if (!rest.includes("--yes")) {
+        throw new Error("history delete requires --yes. This destroys the encrypted store and its local key.\nUsage: " + commandUsage("delete"));
+      }
+      result = await withHistoryLock(root, () => store.hardDelete());
+      break;
+    }
+    default: {
+      throw new Error(`Unknown history subcommand: ${subcommand}\nUsage: opencode-chromium history <enable|disable|pause|resume|status|list|show|delete>`);
+    }
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    const body = await humanSummary(subcommand, result);
+    const notice = subcommand === "enable"
+      ? "Experimental Computer History: records only bounded metadata (capability, hostname, outcome).\nNever stores typed text, screenshots, URLs and paths, arguments, or results.\nEncrypted locally; key at the store root; delete with `opencode-chromium history delete --yes`.\n\n"
+      : "";
+    process.stdout.write(`${notice}${body}`);
+  }
+}
+
+async function humanSummary(subcommand, result) {
+  if (subcommand === "status") {
+    const status = result;
+    return [
+      `history: ${status.health}`,
+      `  enabled: ${status.enabled}`,
+      `  paused: ${status.paused}`,
+      `  encrypted: ${status.encrypted}`,
+      `  profile: ${status.profile}`,
+      `  retention: ${status.retention_days} days`,
+      `  storage: ${bytes(status.bytes_used)} / ${bytes(status.quota_bytes)}`,
+      `  dropped events: ${status.dropped_events}`,
+      `  store: \`${historyRootDir()}\``,
+      "",
+    ].join("\n");
+  }
+  if (subcommand === "list") {
+    const lines = result.events.map((event) => `#${event.data.sequence} ${event.type} ${event.time}${event.data.application?.hostname ? ` › ${event.data.application.hostname}` : ""}`).join("\n");
+    return `${lines || "no events in the retention window"}\n`;
+  }
+  if (subcommand === "show") {
+    if (!result.event) return "no event with that sequence\n";
+    return `${JSON.stringify(result.event, null, 2)}\n`;
+  }
+  return `${JSON.stringify(result, null, 2)}\n`;
+}
+
+function bytes(value) {
+  const units = ["B", "KiB", "MiB"];
+  let amount = Number(value) || 0;
+  let unit = 0;
+  while (amount >= 1024 && unit < units.length - 1) {
+    amount /= 1024;
+    unit += 1;
+  }
+  return `${amount.toFixed(amount >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+export default runHistoryCommand;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,6 +8,7 @@ import { installClient } from "./install.js";
 import { uninstallClient } from "./uninstall.js";
 import { verify } from "./verify.js";
 import { packageInfo } from "./version.js";
+import { runHistoryCommand } from "./history.js";
 
 function valueAfter(argv, flag) {
   const index = argv.indexOf(flag);
@@ -45,8 +46,12 @@ export async function main(argv = process.argv.slice(2)) {
     console.log(JSON.stringify({ ok: true, ...publicResult, changedFiles }, null, 2));
     return;
   }
+  if (command === "history") {
+    await runHistoryCommand(rest);
+    return;
+  }
   if (command === "help" || command === "--help") {
-    console.log("Usage: opencode-chromium <install|configure|uninstall|doctor|verify|mcp|version>");
+    console.log("Usage: opencode-chromium <install|configure|uninstall|doctor|verify|history|mcp|version>");
     return;
   }
   throw new Error(`Unknown command: ${command}`);

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -129,8 +129,8 @@ const resultSchema = z.object({
   error: errorSchema.optional(),
 }).passthrough();
 
-export function createCoreRegistry(runtime) {
-  return {
+export function createCoreRegistry(runtime, { history = false } = {}) {
+  const registry = {
     browser_run: {
       description: "Run an action chain with settle and post-observation.",
       inputSchema: z.object({
@@ -202,6 +202,32 @@ export function createCoreRegistry(runtime) {
       execute: (args, context) => runtime.finalize(args, context),
     },
   };
+
+  if (history) {
+    Object.assign(registry, {
+      history_status: {
+        description: "Report local browser-action history availability, encryption, retention, quota, and health. Read-only; no history content is revealed by this tool.",
+        inputSchema: z.object({}),
+        outputSchema: resultSchema,
+        annotations: { readOnlyHint: true, openWorldHint: true },
+        execute: (args, context) => runtime.historyStatus(args, context),
+      },
+      history_query: {
+        description: "Return bounded metadata-only events recorded for prior browser sessions: which sites, capabilities, and outcomes an earlier run produced, so a continued run can verify state instead of re-exploring from scratch. Events never include URLs, paths, typed text, arguments, or results, and results may enter model context.",
+        inputSchema: z.object({
+          limit: z.number().int().min(1).max(200).optional(),
+          session_id: z.string().min(1).max(128).optional(),
+          since_sequence: z.number().int().min(1).optional(),
+          until_sequence: z.number().int().min(1).optional(),
+        }),
+        outputSchema: resultSchema,
+        annotations: { readOnlyHint: true, openWorldHint: true },
+        execute: (args, context) => runtime.historyQuery(args, context),
+      },
+    });
+  }
+
+  return registry;
 }
 
 export { environmentSchema, observationSchema, resultSchema, settleSchema, stepSchema, targetSchema };

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -4,6 +4,7 @@ import { createBrowserOperations } from "../browser/operations/index.js";
 import { browserRequest, closeBrowserClients, listBrowserProfiles } from "../browser/client.js";
 import { combineUrlPolicyConfig, createUrlPolicy, urlPolicyFromEnv } from "../browser/url-policy.js";
 import { createFilePolicy, filePolicyFromEnv } from "../browser/file-policy.js";
+import { HistoryStore } from "../history/index.js";
 import { ArtifactStore } from "./artifacts.js";
 import { createCapabilityRegistry } from "./capabilities.js";
 import { contractMetadata } from "./versions.js";
@@ -286,6 +287,12 @@ export class AgentBrowserRuntime {
     this.profileCache = { expiresAt: 0, profiles: [] };
     this.legacyToolsPromise = operationFactory().then((hooks) => hooks.tool);
     this.capabilityRegistry = null;
+    this._historyReader = null;
+  }
+
+  historyReader() {
+    if (!this._historyReader) this._historyReader = new HistoryStore();
+    return this._historyReader;
   }
 
   getSession(sessionId) {
@@ -981,6 +988,30 @@ export class AgentBrowserRuntime {
       return { ...contractMetadata(), ok: true, status: "finalized", sessionId, result };
     } catch (error) {
       return this.failure(sessionId, error);
+    }
+  }
+
+  async historyStatus(args = {}, context = {}) {
+    try {
+      const store = this.historyReader();
+      return { ...contractMetadata(), ok: true, status: "ready", result: store.status() };
+    } catch (error) {
+      return this.failure(null, error);
+    }
+  }
+
+  async historyQuery(args = {}, context = {}) {
+    try {
+      const store = this.historyReader();
+      const result = store.query({
+        limit: args.limit,
+        sessionId: args.session_id,
+        sinceSequence: args.since_sequence,
+        untilSequence: args.until_sequence,
+      });
+      return { ...contractMetadata(), ok: true, status: "ready", result };
+    } catch (error) {
+      return this.failure(null, error);
     }
   }
 

--- a/src/history/index.js
+++ b/src/history/index.js
@@ -1,0 +1,1 @@
+export * from "../../native-host/src/history/index.js";

--- a/tests/core/history-tools.test.js
+++ b/tests/core/history-tools.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createCoreRegistry } from "../../src/core/registry.js";
+import { createAgentBrowserRuntime } from "../../src/core/runtime.js";
+
+function noopRuntime() {
+  return { historyStatus: async () => ({ ok: true }), historyQuery: async () => ({ ok: true }) };
+}
+
+test("core registry stays at four tools unless history is enabled", () => {
+  const base = createCoreRegistry(noopRuntime());
+  assert.deepEqual(Object.keys(base), ["browser_run", "browser_observe", "browser_session", "browser_finalize"]);
+  const withHistory = createCoreRegistry(noopRuntime(), { history: true });
+  assert.deepEqual(Object.keys(withHistory), [
+    "browser_run", "browser_observe", "browser_session", "browser_finalize", "history_status", "history_query",
+  ]);
+});
+
+test("history_status reports a disabled store without content", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-tools-"));
+  const previous = process.env.OPENCODE_BROWSER_HISTORY_DIR;
+  process.env.OPENCODE_BROWSER_HISTORY_DIR = root;
+  try {
+    const runtime = createAgentBrowserRuntime();
+    const result = await runtime.historyStatus();
+    assert.equal(result.ok, true);
+    assert.equal(result.result.enabled, false);
+    assert.equal(result.result.encrypted, true);
+    assert.equal(result.result.health, "disabled");
+  } finally {
+    if (previous === undefined) delete process.env.OPENCODE_BROWSER_HISTORY_DIR;
+    else process.env.OPENCODE_BROWSER_HISTORY_DIR = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("history_query returns bounded metadata-only slices", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-tools-"));
+  const previous = process.env.OPENCODE_BROWSER_HISTORY_DIR;
+  process.env.OPENCODE_BROWSER_HISTORY_DIR = root;
+  try {
+    const runtime = createAgentBrowserRuntime();
+    const query = await runtime.historyQuery({ limit: 10 });
+    assert.equal(query.ok, true);
+    assert.equal(query.result.events.length, 0);
+    assert.equal(query.result.metadata_only, true);
+    assert.equal(query.result.model_context_disclosure, true);
+  } finally {
+    if (previous === undefined) delete process.env.OPENCODE_BROWSER_HISTORY_DIR;
+    else process.env.OPENCODE_BROWSER_HISTORY_DIR = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/native-host/history-relay.test.js
+++ b/tests/native-host/history-relay.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { HistoryCapture, HistoryStore } from "../../native-host/src/history/index.js";
+import { RpcRelay } from "../../native-host/src/rpc-relay.js";
+
+function fakeSocket() {
+  return {
+    destroy() {},
+    on() {},
+    write(_chunk, callback) {
+      if (typeof callback === "function") callback();
+    },
+  };
+}
+
+test("the native host relay records agent actions as encrypted history events", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-relay-"));
+  const store = new HistoryStore({ root });
+  try {
+    store.enable();
+    const capture = new HistoryCapture({ store });
+    const extensionOut = [];
+    const relay = new RpcRelay({
+      state: { startedAt: new Date().toISOString() },
+      extensionWriter: (message) => extensionOut.push(message),
+      history: capture,
+      localHandler: async () => undefined,
+    });
+
+    const socket = fakeSocket();
+    await relay.handleClientMessage(socket, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "finalizeTabs",
+      params: { session_id: "relay-session", profile_id: "p1", keep: [1] },
+    });
+    const forwarded = extensionOut.find((message) => message.method === "finalizeTabs");
+    assert.ok(forwarded, "agent request must be forwarded to the extension");
+    await relay.handleExtensionMessage({
+      jsonrpc: "2.0",
+      id: forwarded.id,
+      result: { profiles: {} },
+    });
+    store.flushSync();
+
+    const events = store.list({ limit: 50 }).events;
+    const started = events.find((event) => event.type === "opencode-browser-plugin.history.action_started.v0");
+    const completed = events.find((event) => event.type === "opencode-browser-plugin.history.action_completed.v0");
+    assert.ok(started, "action_started recorded");
+    assert.ok(completed, "action_completed recorded");
+    assert.equal(completed.data.session_id, "relay-session");
+    assert.equal(completed.data.capability, "browser.session.finalize");
+    assert.equal(completed.data.payload.effect, "confirmed");
+    assert.equal(completed.data.action_id, started.data.action_id);
+  } finally {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the native host relay marks failed and timed-out actions", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-relay-"));
+  const store = new HistoryStore({ root });
+  try {
+    store.enable();
+    const capture = new HistoryCapture({ store });
+    const extensionOut = [];
+    const relay = new RpcRelay({
+      state: { startedAt: new Date().toISOString() },
+      extensionWriter: (message) => extensionOut.push(message),
+      history: capture,
+      localHandler: async () => undefined,
+    });
+
+    const socket = fakeSocket();
+    await relay.handleClientMessage(socket, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "closeTab",
+      params: { session_id: "relay-session", tabId: 7 },
+    });
+    const forwarded = extensionOut.find((message) => message.method === "closeTab");
+    await relay.handleExtensionMessage({
+      jsonrpc: "2.0",
+      id: forwarded.id,
+      error: { code: -32000, message: "boom", data: { code: "BABOOM" } },
+    });
+    store.flushSync();
+
+    const events = store.list({ limit: 50 }).events;
+    const failed = events.find((event) => event.type === "opencode-browser-plugin.history.action_completed.v0" && event.data.capability === "browser.tab.close");
+    assert.ok(failed);
+    assert.equal(failed.data.payload.effect, "failed");
+    assert.equal(failed.data.payload.error_code, "BABOOM");
+    const serialized = JSON.stringify(events);
+    assert.equal(serialized.includes("boom"), false, "raw error text must not be stored");
+  } finally {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/native-host/history.test.js
+++ b/tests/native-host/history.test.js
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { HistoryCapture, HistoryStore, WRITER_QUEUE_CAPACITY, historyHealth, readState } from "../../native-host/src/history/index.js";
+
+function tempStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-test-"));
+  const store = new HistoryStore({ root });
+  return { root, store };
+}
+
+function cleanupStore({ root, store }) {
+  try {
+    store.close();
+  } catch {
+    // ignore
+  }
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+test("capture is off by default and never touches disk", () => {
+  const { root, store } = tempStore();
+  try {
+    const result = store.record({ kind: "action_started", sessionId: "s1", capability: "browser.tab.create" });
+    assert.equal(result.accepted, false);
+    assert.equal(result.reason, "disabled");
+    assert.equal(store.status().enabled, false);
+    assert.equal(fs.existsSync(path.join(root, "key")), false);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("enable creates an encrypted store and records control events", () => {
+  const { root, store } = tempStore();
+  try {
+    const status = store.enable();
+    assert.equal(status.enabled, true);
+    assert.equal(status.encrypted, true);
+    assert.equal(status.health, "ready");
+    assert.ok(fs.statSync(path.join(root, "key")).size === 32);
+    const events = store.list({ limit: 10 }).events;
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "opencode-browser-plugin.history.control.v0");
+    assert.equal(events[0].data.payload.operation, "enable");
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("action events round-trip with fixed metadata only", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.record({ kind: "action_started", sessionId: "s1", actionId: "a1", capability: "browser.tab.claim", application: { hostname: "github.com" } });
+    store.record({ kind: "action_completed", sessionId: "s1", actionId: "a1", capability: "browser.tab.claim", application: { hostname: "github.com" }, payload: { kind: "action_completed", effect: "confirmed", route: "relay" } });
+    store.flushSync();
+    const events = store.list({ limit: 10 }).events;
+    const completed = events.find((event) => event.type === "opencode-browser-plugin.history.action_completed.v0");
+    assert.ok(completed);
+    assert.equal(completed.data.session_id, "s1");
+    assert.equal(completed.data.action_id, "a1");
+    assert.equal(completed.data.capability, "browser.tab.claim");
+    assert.deepEqual(completed.data.application, { hostname: "github.com" });
+    assert.equal(completed.data.payload.effect, "confirmed");
+    assert.equal(completed.data.platform, process.platform);
+    assert.equal(JSON.stringify(completed).includes("https://"), false);
+    assert.equal(completed.data.url, undefined);
+    assert.equal(completed.data.arguments, undefined);
+    assert.equal(completed.data.result, undefined);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("raw key material never appears on disk outside the key file", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.record({ kind: "action_started", sessionId: "s1", capability: "browser.pointer.move", application: { hostname: "example.com" } });
+    store.flushSync();
+    const chunk = path.join(root, "chunks");
+    const files = fs.readdirSync(chunk).filter((name) => name.endsWith(".chunk"));
+    assert.equal(files.length, 1);
+    const raw = fs.readFileSync(path.join(chunk, files[0]), "utf8");
+    assert.equal(raw.includes("browser.pointer.move"), false);
+    assert.equal(raw.includes("example.com"), false);
+    assert.equal(raw.includes('"session_id"'), false);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("pause stops capture but preserves the store; resume restores it", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.pause();
+    assert.equal(store.status().paused, true);
+    const before = store.list({ limit: 50 }).events.length;
+    store.record({ kind: "action_started", sessionId: "s2", capability: "browser.tab.create" });
+    store.flushSync();
+    const after = store.list({ limit: 50 }).events.length;
+    assert.equal(after, before);
+    store.resume();
+    store.record({ kind: "action_completed", sessionId: "s2", capability: "browser.tab.create" });
+    store.flushSync();
+    assert.ok(store.list({ limit: 50 }).events.length > before);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("dropped events are counted without blocking capture", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.queue = new Array(WRITER_QUEUE_CAPACITY).fill({});
+    store.record({ kind: "action_started", sessionId: "s3", capability: "browser.tab.create" });
+    assert.equal(store.status().dropped_events, 1);
+    store.queue = [];
+    store.hardDelete();
+    store.enable();
+    store.flushSync();
+    assert.ok(true);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("retention hides events older than the window", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    const old = { ...(store.record({ kind: "control", payload: { kind: "control", operation: "enable" } }).event ?? {}) };
+    void old;
+    const fresh = store.record({ kind: "control", payload: { kind: "control", operation: "enable" } });
+    void fresh;
+    store.flushSync();
+    const chunkFile = path.join(root, "chunks", fs.readdirSync(path.join(root, "chunks")).find((name) => name.endsWith(".chunk")));
+    const before = store.list({ limit: 50 }).events.length;
+    assert.ok(before >= 1);
+    const mtime = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(chunkFile, new Date(mtime), new Date(mtime));
+    const cutoffRoll = 30 * 24 * 60 * 60 * 1000;
+    const future = Date.now() + cutoffRoll;
+    store.pruneExpired(future);
+    const after = store.list({ limit: 50 }).events.length;
+    assert.equal(after, 0);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("corrupt chunks fail closed instead of guessing", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.record({ kind: "action_started", sessionId: "s4", capability: "browser.tab.create" });
+    store.flushSync();
+    const chunks = path.join(root, "chunks");
+    const good = fs.readdirSync(chunks).find((name) => name.endsWith(".chunk"));
+    assert.ok(good);
+    store.close();
+    const corruptFile = path.join(chunks, `${Date.now() + 100000}-corrupt.chunk`);
+    fs.writeFileSync(corruptFile, "{\"v\":1,\"profile\":\"opencode-browser-plugin-history-v1/aes-256-gcm+jsonl+cloudevents-json\",\"chunkId\":\"x\",\"created\":\"now\",\"sealed\":true}\nAAAA\n");
+    const reader = new HistoryStore({ root });
+    const result = reader.query({ limit: 50 });
+    assert.equal(result.events.length, 2);
+    assert.match(result.health_warning ?? "", /unauthenticated|malformed|corrupt/i);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("queries append an encrypted access-audit record when non-empty", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.record({ kind: "action_started", sessionId: "s5", capability: "browser.tab.create" });
+    store.flushSync();
+    store.query({ limit: 10 });
+    store.flushSync();
+    const events = store.list({ limit: 50 }).events;
+    assert.ok(events.some((event) => event.type === "opencode-browser-plugin.history.access.v0"));
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("query honors session, sequence bounds, and the limit cap", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    for (let index = 0; index < 5; index += 1) store.record({ kind: "action_started", sessionId: "s6", capability: "browser.tab.create" });
+    store.flushSync();
+    const all = store.query({ limit: 200 }).events;
+    assert.ok(all.length >= 5);
+    const sessionOnly = store.query({ limit: 200, sessionId: "does-not-exist" }).events;
+    assert.equal(sessionOnly.length, 0);
+    const bounded = store.query({ limit: 2 }).events;
+    assert.equal(bounded.length, 2);
+    const sequences = bounded.map((event) => event.data.sequence).sort((a, b) => a - b);
+    assert.ok(sequences[1] > sequences[0]);
+    const unbounded = store.query({ limit: 9999 }).events;
+    assert.ok(unbounded.length <= 200);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("hardDelete destroys the key, chunks, and state", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    store.record({ kind: "action_started", sessionId: "s7", capability: "browser.tab.create" });
+    store.flushSync();
+    const result = store.hardDelete();
+    assert.equal(result.deleted, true);
+    assert.equal(fs.existsSync(path.join(root, "key")), false);
+    assert.equal(fs.existsSync(path.join(root, "state.json")), false);
+    assert.deepEqual(readState(root), { enabled: false, paused: false, sequence: 0, dropped: 0, corrupt: false, admitted: false, createdAt: null });
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("health categories reflect lifecycle", () => {
+  const { root, store } = tempStore();
+  try {
+    assert.equal(store.status().health, "disabled");
+    store.enable();
+    assert.equal(store.status().health, "ready");
+    store.pause();
+    assert.equal(store.status().health, "paused");
+    const state = readState(root);
+    state.corrupt = true;
+    fs.writeFileSync(path.join(root, "state.json"), JSON.stringify(state));
+    assert.equal(historyHealth(readState(root)), "storage_corrupt");
+  } finally {
+    cleanupStore({ root, store });
+  }
+});
+
+test("capture maps only agent actions with sessions and never records args", () => {
+  const { root, store } = tempStore();
+  try {
+    store.enable();
+    const capture = new HistoryCapture({ store });
+    const started = capture.startAgentRequest({
+      id: 1,
+      method: "claimUserTab",
+      params: { session_id: "s8", tabId: 42, url: "https://github.com/example/path?q=1" },
+    });
+    assert.ok(started);
+    assert.equal(started.sessionId, "s8");
+    assert.equal(capture.applicationFor(42), null);
+    capture.noteResponse({ id: 1, tabs: [{ id: 42, url: "https://github.com/acme/repo" }] });
+    assert.deepEqual(capture.applicationFor(42), { hostname: "github.com" });
+    capture.completeAgentRequest(started, "confirmed");
+    const skipped = capture.startAgentRequest({ id: 2, method: "getTabs", params: { session_id: "s8" } });
+    assert.equal(skipped, null);
+    const noSession = capture.startAgentRequest({ id: 3, method: "closeTab", params: { tabId: 42 } });
+    assert.equal(noSession, null);
+    store.flushSync();
+    const events = store.list({ limit: 50 }).events;
+    const completed = events.find((event) => event.type === "opencode-browser-plugin.history.action_completed.v0");
+    assert.ok(completed);
+    assert.deepEqual(completed.data.application, { hostname: "github.com" });
+    const serialized = JSON.stringify(events);
+    assert.equal(serialized.includes("https://"), false);
+    assert.equal(serialized.includes("acme"), false);
+    assert.equal(serialized.includes("q=1"), false);
+  } finally {
+    cleanupStore({ root, store });
+  }
+});


### PR DESCRIPTION
A local, **off-by-default** record of agent-mediated browser actions so continued sessions hydrate from metadata instead of re-exploring pages from scratch — with the strict privacy boundary users expect.

## What it does
- **Encrypted at rest:** every record is AES-256-GCM encrypted before touching disk, with a per-chunk HKDF-derived key and a user-only key file. No plaintext fallback, no network I/O.
- **Metadata only:** fixed capability enum, action outcome, hostname app identity, opaque session/action ids, sequence, lifecycle, and health events. URLs, paths, titles, typed text, keystrokes, clipboard contents, arguments, and results are **never** stored — pinned by tests.
- **Non-blocking:** capture is a bounded queue in the native host; history can never slow or fail the originating browser action.
- **Lifecycle CLI:** \opencode-chromium history enable|disable|pause|resume|status|list|show|delete --yes\, 7-day retention and 100 MiB quota, cryptographic delete (key destroyed before files).
- **Agent surface:** \history_status\ + \history_query\ read-only tools register only when enabled; queries are bounded (\u2264200), return a model-context disclosure, and append an encrypted access-audit record.
- **Consultation policy:** the bundled skill and MCP instructions consult history only for continue/resume/recall requests, use it as metadata-only leads, and degrade gracefully.

## Files of interest
- \
ative-host/src/history/\ — store, crypto, events allowlist, capture, config
- \
ative-host/src/rpc-relay.js\ — capture chokepoint for every agent browser RPC
- \src/cli/history.js\ — lifecycle commands
- \src/core/registry.js\ — gated history tools
- \docs/computer-history.md\ — feature, storage, privacy, and troubleshooting docs
- 15 new tests across store, capture, relay wiring, tools, and registry parity